### PR TITLE
Don't write the final null byte to the client

### DIFF
--- a/main.c
+++ b/main.c
@@ -97,7 +97,7 @@ int main(int argc __attribute__((unused)),
 		read(client, recvbuf, BUFLEN);
 
 		/* Send reply */
-		n = write(client, reply, sizeof(reply));
+		n = write(client, reply, sizeof(reply) - 1);
 		if (n < 0)
 			fprintf(stderr, "Failed to send a reply\n");
 		else


### PR DESCRIPTION
The sizeof of the array will include the trailing null byte. This causes curl to interpret the response as binary data.

Signed-off-by: Marco Schlumpp <marco@unikraft.io>