### PR TITLE
kraft.yaml: Add arm64 architecture

### DIFF
--- a/kraft.yaml
+++ b/kraft.yaml
@@ -10,6 +10,8 @@ unikraft:
 targets:
   - architecture: x86_64
     platform: kvm
+  - architecture: arm64
+    platform: kvm
 libraries:
   lwip:
     version: stable


### PR DESCRIPTION
Add `arm64` for `kvm` platform. Tested with ARM tool chain 11.2-2022.02 (`aarch64-none-linux-gnu`).