### PR TITLE
Add KraftKit configuration file for KraftCloud

### DIFF
--- a/kraft.cloud.yaml
+++ b/kraft.cloud.yaml
@@ -1,0 +1,26 @@
+specification: '0.5'
+name: httpreply
+unikraft:
+  version: cloud
+  kconfig:
+    - CONFIG_LIBNOLIBC=y
+    - CONFIG_LIBUKSCHED=y
+    - CONFIG_LIBUKSCHEDCOOP=y
+targets:
+  - name: kraftcloud-x86_64
+    architecture: x86_64
+    platform: firecracker
+libraries:
+  lwip:
+    version: stable
+    kconfig:
+      - CONFIG_LWIP_UKNETDEV=y
+      - CONFIG_LWIP_TCP=y
+      - CONFIG_LWIP_THREADS=y
+      - CONFIG_LWIP_SOCKET=y
+      - CONFIG_LWIP_AUTOIFACE=y
+      - CONFIG_LWIP_IPV4=y
+      - CONFIG_LWIP_SOCKET_PPOLL=n
+  ukp-bin:
+    source: https://github.com/unikraft-io/lib-ukp-bin
+    version: stable


### PR DESCRIPTION
Add `kraft.cloud.yaml` configuration file to build and run for KraftCloud.

Build with:

```console
kraft build --kraftfile kraft.cloud.yaml -j $(nproc)
```

Run with:

```console
sudo kraft net create -n 172.44.0.1/24 kraft0
sudo kraft run --kraftfile kraft.cloud.yaml --network bridge:kraft0 --plat firecracker -a netdev.ipv4_addr=172.44.0.2 -a netdev.ipv4_gw_addr=172.44.0.1 -a netdev.ipv4_subnet_mask=255.255.255.0 -- httpreply
```